### PR TITLE
Rename Locations table and references to 'ResidencyLocations'

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,7 +3,7 @@ class UsersController < ApplicationController
     if current_user.admin?
       @users = User.where(admin: false).order("trainer DESC")
     elsif current_user.trainer?
-      @users = User.where(admin: false, trainer: false, location_id: current_user.location_id)
+      @users = User.where(admin: false, trainer: false, residency_location_id: current_user.residency_location_id)
     else
       redirect_to user_path(current_user)
     end
@@ -11,7 +11,8 @@ class UsersController < ApplicationController
 
   def show
     @user = User.find_by(id: params[:id])
-    # @location = Location.find(params[:location_id])
+
+    #@resdency_location = ResidencyLocation.find_by(id: params[:residency_location_id])
 
     # Uncomment after Procedure Table is created
     # @procedures = Procedure.all.where(user_id = @user.id)
@@ -62,7 +63,7 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:email, :name, :location_id, :status, :trainer,
+    params.require(:user).permit(:email, :name, :residency_location_id, :status, :trainer,
     :admin)
   end
 

--- a/db/migrate/20170305181204_change_locations_to_residency_locations.rb
+++ b/db/migrate/20170305181204_change_locations_to_residency_locations.rb
@@ -1,0 +1,7 @@
+class ChangeLocationsToResidencyLocations < ActiveRecord::Migration[5.0]
+  def change
+    rename_table :locations, :residency_locations
+
+    rename_column :users, :location_id, :residency_location_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,16 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170305033558) do
+ActiveRecord::Schema.define(version: 20170305181204) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-
-  create_table "locations", force: :cascade do |t|
-    t.string   "name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
 
   create_table "procedures", force: :cascade do |t|
     t.string   "resident"
@@ -32,6 +26,12 @@ ActiveRecord::Schema.define(version: 20170305033558) do
     t.string   "residentstatus"
     t.datetime "created_at",     null: false
     t.datetime "updated_at",     null: false
+  end
+
+  create_table "residency_locations", force: :cascade do |t|
+    t.string   "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "users", force: :cascade do |t|
@@ -49,7 +49,7 @@ ActiveRecord::Schema.define(version: 20170305033558) do
     t.datetime "updated_at",                             null: false
     t.boolean  "admin",                  default: false
     t.boolean  "trainer",                default: false
-    t.integer  "location_id"
+    t.integer  "residency_location_id"
     t.string   "name"
     t.string   "status"
     t.string   "invitation_token"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,7 @@
 # This file should contain all the record creation needed to seed the database with its default values.
 # The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
 
-locations = Location.create([{name: 'San Francisco'}, {name: 'Contra Costa'}])
+locations = ResidencyLocation.create([{name: 'San Francisco'}, {name: 'Contra Costa'}])
 
-User.create({email: 'test@gmail.com', password: 'password', password_confirmation: 'password', name: 'Test1', admin: true, trainer: true, location_id: locations.first.id})
-User.create({email: 'test2@gmail.com', password: 'password', password_confirmation: 'password', name: 'Test2', status: 'R2', location_id: locations.first.id})
+User.create({email: 'test@gmail.com', password: 'password', password_confirmation: 'password', name: 'Test1', admin: true, trainer: true, residency_location_id: locations.first.id})
+User.create({email: 'test2@gmail.com', password: 'password', password_confirmation: 'password', name: 'Test2', status: 'R2', residency_location_id: locations.first.id})


### PR DESCRIPTION
Migration to change 'locations' table to 'residency_locations'
rename references to 'locations' to use 'residency_locations'